### PR TITLE
Bump metrics to 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <config-version>1.1</config-version>
         <ft-version>1.0-SNAPSHOT</ft-version>
         <health-version>1.0-SNAPSHOT</health-version>
-        <metrics-version>1.0-SNAPSHOT</metrics-version>
+        <metrics-version>1.0</metrics-version>
         <jwt-version>1.0-SNAPSHOT</jwt-version>
 
         <!-- other props  -->


### PR DESCRIPTION
Microprofile Metrics 1.0 has been tagged.

This one can be merged once the artefacts are available.
Fixes #23 

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>