### PR TITLE
update spec pom.xml for proper html generation

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -82,6 +82,11 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
+                            <attributes>
+                                <revnumber>${project.version}</revnumber>
+                                <revremark>${revremark}</revremark>
+                                <revdate>${revisiondate}</revdate>
+                            </attributes>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Here's the change we need in the spec pom.xml for proper html generation. I have also created this 1.3-branch which we will keep around. I have manually updated the artifacts for the 1.3 Release tag to include the Final 1.3 spec html (pdf was okay). This change should resolve issue #71.

I propose that we take the educated risk that the eclipse repository for the spec html document either won't be accessed or it won't be noticed that the version is blank. Remember, the pdf is good.  The content is still 1.3 and is accurate. It's just the version tag that was incorrect. We should be able to live with that until we do the next 1.x or 2.x release of microprofile.